### PR TITLE
Disable early return forcing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,12 @@ Style/AsciiComments:
 
 Style/ModuleFunction:
   Enabled: false
+  
+Style/Next:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
 
 Metrics/LineLength:
   Max: 120


### PR DESCRIPTION
The way Rubocop forces us to use early returns is quite subjective, so it's better to disable it.

https://github.com/bbatsov/rubocop/issues/1138
https://github.com/bbatsov/rubocop/issues/1238#issuecomment-51214359