### PR TITLE
Fix Style/MultilineMethodCallIndentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,3 +43,6 @@ Metrics/CyclomaticComplexity:
 
 Style/SignalException:
   EnforcedStyle: semantic
+  
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented  


### PR DESCRIPTION
Use EnforcedStyle: indented instead of aligned

```
# bad
while a
.b
  something
end

# good, EnforcedStyle: aligned
while a
      .b
  something
end

# good, EnforcedStyle: aligned
Thing.a
     .b
     .c

# good, EnforcedStyle: indented
while a
    .b
  something
end
```