### PR TITLE
Enforce consistent style while indenting arrays

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,3 +46,7 @@ Style/SignalException:
   
 Style/MultilineMethodCallIndentation:
   EnforcedStyle: indented  
+  
+Style/IndentArray:
+  EnforcedStyle: consistent
+


### PR DESCRIPTION
Before:

```ruby
array = [
  :value
]
but_in_a_method_call([
                       :its_like_this
                     ])
```

After:

```ruby
array = [
  :value
]
and_in_a_method_call([
  :no_difference
])
```