### PR TITLE
Feature/align parameters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,10 +43,13 @@ Metrics/CyclomaticComplexity:
 
 Style/SignalException:
   EnforcedStyle: semantic
-  
+
 Style/MultilineMethodCallIndentation:
-  EnforcedStyle: indented  
-  
+  EnforcedStyle: indented
+
 Style/IndentArray:
   EnforcedStyle: consistent
+
+Style/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
 

--- a/lib/spbtv_code_style.rb
+++ b/lib/spbtv_code_style.rb
@@ -1,4 +1,4 @@
 # Just namespace for version number
 module SpbtvCodeStyle
-  VERSION = '1.3.1'.freeze
+  VERSION = '1.3.2'.freeze
 end


### PR DESCRIPTION
В рамках программы по искоренению топоров из кода:

Alignment of parameters in multi-line method calls.
Before:

```ruby
method_call(a,
            b
           )
```

After:

```ruby
method_call(a,
  b
)
```