### PR TITLE
Feature/closing parenthesis indentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,3 +53,5 @@ Style/IndentArray:
 Style/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
+Style/ClosingParenthesisIndentation:
+  Enabled: false

--- a/lib/spbtv_code_style.rb
+++ b/lib/spbtv_code_style.rb
@@ -1,4 +1,4 @@
 # Just namespace for version number
 module SpbtvCodeStyle
-  VERSION = '1.3.2'.freeze
+  VERSION = '1.3.3'.freeze
 end


### PR DESCRIPTION
Before this change rubocop forses us to write code like this:

```ruby
create(:movie,
  :with_genres,
  :with_trailer
      )
```

After this change you are free to place closing parenthesis at the begining of the string (but this is not forced)