### PR TITLE
Feature/update rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,3 +53,14 @@ Style/MultilineMethodCallIndentation:
 Style/IndentArray:
   EnforcedStyle: consistent
 
+Style/MultilineMethodCallBraceLayout:
+  EnforcedStyle: same_line
+
+Style/ClosingParenthesisIndentation:
+  Enabled: false
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: no_comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,7 +54,7 @@ Style/IndentArray:
   EnforcedStyle: consistent
 
 Style/MultilineMethodCallBraceLayout:
-  EnforcedStyle: same_line
+  Enabled: false
 
 Style/ClosingParenthesisIndentation:
   Enabled: false
@@ -63,4 +63,4 @@ Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: no_comma
+  EnforcedStyleForMultiline: comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,9 @@ Style/TrivialAccessors:
 Style/IfUnlessModifier:
   MaxLineLength: 30
 
+Style/EmptyCaseCondition:
+  Enabled: false
+
 Metrics/AbcSize:
   Severity: refactor
 
@@ -43,10 +46,10 @@ Metrics/CyclomaticComplexity:
 
 Style/SignalException:
   EnforcedStyle: semantic
-  
+
 Style/MultilineMethodCallIndentation:
-  EnforcedStyle: indented  
-  
+  EnforcedStyle: indented
+
 Style/IndentArray:
   EnforcedStyle: consistent
 

--- a/.strict_rubocop.yml
+++ b/.strict_rubocop.yml
@@ -1,0 +1,17 @@
+inherit_from:
+  - .rubocop.yml
+
+Metrics/AbcSize:
+  Severity: warning
+
+Metrics/PerceivedComplexity:
+  Severity: warning
+
+Metrics/ParameterLists:
+  Severity: warning
+
+Metrics/MethodLength:
+  Severity: warning
+
+Metrics/CyclomaticComplexity:
+  Severity: warning

--- a/lib/spbtv_code_style.rb
+++ b/lib/spbtv_code_style.rb
@@ -1,4 +1,4 @@
 # Just namespace for version number
 module SpbtvCodeStyle
-  VERSION = '1.3.1'.freeze
+  VERSION = '1.4.0'.freeze
 end

--- a/spbtv_code_style.gemspec
+++ b/spbtv_code_style.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.38.0'
+  spec.add_runtime_dependency 'rubocop', '0.40.0'
   spec.add_runtime_dependency 'rubocop-checkstyle_formatter'
   spec.add_runtime_dependency 'rspec_junit_formatter'
 


### PR DESCRIPTION
* Обновил рубокоп до последней версии
* Добавил `.strict_rubocop.yml` где для метрик кода severity изменена на warning
* Поменял стили:

```yml
Style/MultilineMethodCallBraceLayout:
  EnforcedStyle: same_line
```

* `symmetrical`: closing brace is positioned in same way as opening brace. Это вариант заставляет вешать скобку посреди строки. На мой взгляд, этому правилу сложно следовать, нужно как-то особо настраивать IDE.
* `new_line`: closing brace is always on a new line. Этот вариант приводит к абсолютно не адекватному рельзутату. Например

```ruby
  let(:foo
) do 
  #... 
end
```
* `same_line`: closing brace is always on the same line as last argument. В итоге остановился на этом варианте:


```ruby
let(:channel) do 
  create(:channel, name: 'MTV')
end

let(:movie) do 
  create(
    :movie, 
    name: 'MTV',
    length: 1.hour)
end
```

 ```yml
Style/ClosingParenthesisIndentation:
  Enabled: false
```

Эта проверка и так была отключена, просто вынес её в общий код.

```ruby
Style/TrailingCommaInLiteral:
  EnforcedStyleForMultiline: comma
```

Заставляет ставить запятую в конце многострочных массивов и хэшей.

* If `comma`, the cop requires a comma after the last item in an array or hash, but only when each item is on its own line. Например,

```ruby
[1, 2, 3]

[
  1, 
  2, 
  3,
]

[
  1, 2, 
  3
]
```

* If `consistent_comma`, the cop requires a comma after the last item of all non-empty array and hash literals. Например,

```ruby
[1, 2, 3]

[
  1, 
  2, 
  3,
]

[
  1, 2, 
  3,
]
```

```yml
Style/TrailingCommaInArguments:
  EnforcedStyleForMultiline: no_comma
```
Ставит запятую после последнего аргумента при вызове функции. Опции такие же как и у предыдущего копа.