### PR TITLE
Removed rubocop-rspec from .rubocop.yml since the gem is not in depen…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,4 @@
 require:
-  - rubocop-rspec
   - ./lib/rubocop/cop/spbtv/postgres/add_column_with_default
   - ./lib/rubocop/cop/spbtv/postgres/add_column_with_not_null
   - ./lib/rubocop/cop/spbtv/postgres/add_index


### PR DESCRIPTION
…dencies